### PR TITLE
Allow override of APP_PATH

### DIFF
--- a/fw/platforms/cc3200/Makefile
+++ b/fw/platforms/cc3200/Makefile
@@ -4,7 +4,7 @@ SJS_CC3200_PATH = $(REPO_PATH)/fw/platforms/cc3200
 SDK_VERSION ?= $(shell cat $(SJS_CC3200_PATH)/sdk.version)
 
 REPO_ABS_PATH = $(realpath $(REPO_PATH))
-APP_PATH = $(subst $(REPO_ABS_PATH),/src,$(CURDIR))
+APP_PATH ?= $(subst $(REPO_ABS_PATH),/src,$(CURDIR))
 
 .PHONY: all clean
 


### PR DESCRIPTION
This would permit building applications out-of-tree -- APP_PATH can
be set to an additional docker mount added via DOCKER_EXTRA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose-iot/141)
<!-- Reviewable:end -->
