### PR TITLE
Fixed circular dependency of build_info.c/.o

### DIFF
--- a/fw/platforms/posix/Makefile
+++ b/fw/platforms/posix/Makefile
@@ -225,7 +225,7 @@ $(GENFILES_FLAG): $(GENFILES_LIST)
 # Generate build info. Only regenerates if there are changes in objects.
 include $(REPO_PATH)/common/scripts/build_info.mk
 
-$(BUILD_INFO_C): $(OBJS)
+$(BUILD_INFO_C): $(APP_OBJS)
 	$(call gen_build_info,$@,,,,,$(BUILD_INFO_C),)
 
 -include $(wildcard $(BUILD_DIR)/*.d)


### PR DESCRIPTION
I tried building fw/platforms/posix.
Wouldn't build due to:
 Circular .build/build_info.c <- .build/build_info.o dependency dropped.
LD bin/mongoose-iot

Looking at the Makefile:
OBJS = $(APP_OBJS) $(BUILD_DIR)/build_info.o

$(BUILD_DIR)/build_info.o: $(BUILD_INFO_C)
	$(call compile,)

$(BUILD_INFO_C): $(OBJS)
	$(call gen_build_info,$@,,,,,$(BUILD_INFO_C),)

So build_info.o depends on build_info.c, but build_info.c depends on build_info.o from the inclusion of build_info.o in the OBJS variable.

Simply using APP_OBJS instead fixes the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose-iot/159)
<!-- Reviewable:end -->
